### PR TITLE
Fix FileDescriptor leaks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Deploying to Nexus
 
 **This section applies only to project owners**
 
-The JARs must be signed and you must have access to upload to Sonatype, so you need a GPG key and a Sonatype login.
+The JARs must be signed, and you must have access to upload to Sonatype, so you need a GPG key and a Sonatype login.
 The passwords for this should be in your Maven `settings.xml` with the following config:
 
 	<settings>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Restabuild
 ----------
 
-Your self-hosted build server that let's you quickly build projects from a RESTful interface only.
+Your self-hosted build server that lets you quickly build projects from a RESTful interface only.
 Simply place `build.sh` (or `build.bat` if the build server is Windows) into the root of your project
 and then `POST` to `/restabuild/api/v1/builds` with `gitUrl` as a form parameter. The web UI gives
 more detail on the API along with sample curl commands.
@@ -16,7 +16,7 @@ Configuration
 -------------
 
 See `sample-config.properties` for configuration information. Each setting can be specified
-as an environment variable, a java system property, or in a properties file who's path is
+as an environment variable, a java system property, or in a properties file whose path is
 specified as a command line argument.
 
 Running

--- a/pom.xml
+++ b/pom.xml
@@ -68,12 +68,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>3.11</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.13</version>
+            <version>1.15</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/danielflower/restabuild/build/BuildResult.java
+++ b/src/main/java/com/danielflower/restabuild/build/BuildResult.java
@@ -22,7 +22,7 @@ public class BuildResult {
     private volatile BuildState state = BuildState.QUEUED;
     private final GitRepo gitRepo;
     private volatile StringBuffer buildLog = new StringBuffer();
-    private File buildLogFile;
+    private final File buildLogFile;
     private final List<StringListener> logListeners = new CopyOnWriteArrayList<>();
     public final long queueStart = System.currentTimeMillis();
     private long buildStart = -1;
@@ -30,7 +30,7 @@ public class BuildResult {
     private String commitIDBeforeBuild;
     private String commitIDAfterBuild;
     private List<String> createdTags;
-    private String buildParam;
+    private final String buildParam;
     private final Map<String, String> environment;
 
     public BuildResult(FileSandbox sandbox, GitRepo gitRepo, String buildParam, String id, Map<String, String> environment) {
@@ -86,8 +86,7 @@ public class BuildResult {
         buildStart = System.currentTimeMillis();
         try (FileWriter logFileWriter = new FileWriter(buildLogFile);
              Writer writer = new MultiWriter(logFileWriter)) {
-            try {
-                ProjectManager pm = ProjectManager.create(gitRepo.url, sandbox, writer);
+            try (ProjectManager pm = ProjectManager.create(gitRepo.url, sandbox, writer)) {
                 extendedBuildState = pm.build(writer, gitRepo.branch, buildParam, buildTimeout, environment);
                 newState = extendedBuildState.buildState;
             } catch (Exception ex) {

--- a/src/test/java/com/danielflower/restabuild/build/ProjectManagerTest.java
+++ b/src/test/java/com/danielflower/restabuild/build/ProjectManagerTest.java
@@ -30,6 +30,7 @@ public class ProjectManagerTest {
         assertThat(buildLog.toString(), extendedBuildState.buildState, is(BuildState.SUCCESS));
         assertThat(buildLog.toString(), containsString("BUILD SUCCESS"));
         assertThat(extendedBuildState.tagsAdded, contains("my-maven-app-1.0.0"));
+        assertThat("workDir does not still exist", extendedBuildState.workDir.exists(), is(false));
 
         breakTheProject(appRepo, "master");
 
@@ -37,6 +38,7 @@ public class ProjectManagerTest {
         BuildState result2 = runner.build(badBuildLog, "master", null, defaultTimeout, System.getenv()).buildState;
         assertThat(buildLog.toString(), result2, is(BuildState.FAILURE));
         assertThat(badBuildLog.toString(), containsString("The build could not read 1 project"));
+        assertThat("workDir does not still exist", extendedBuildState.workDir.exists(), is(false));
 
     }
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -7,6 +7,7 @@
     </appender>
 
     <logger name="org.eclipse.jetty" level="WARN" />
+    <logger name="com.danielflower.restabuild" level="DEBUG" />
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
ProjectManager
- add a close method that closes the repo (and implement AutoCloseable)
- close build-instance repo after build
- delete the workDir with OVERRIDE_READ_ONLY
BuildResult
- close ProjectManager after build so the repo is closed

This deliberately doesn't attempt to delete the build-instance workDir on exception.
It did not before, and I assume that's because it might be useful to see what happened, so I left it that way.

Fixes #8 