### PR TITLE
If no branch is specified, use any advertised default, not just master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>5.5.1.201910021850-r</version>
+            <version>5.10.0.202012080955-r</version>
         </dependency>
         <!-- end git stuff -->
 

--- a/src/main/java/com/danielflower/restabuild/web/BuildResource.java
+++ b/src/main/java/com/danielflower/restabuild/web/BuildResource.java
@@ -12,6 +12,7 @@ import io.muserver.MuResponse;
 import io.muserver.rest.ApiResponse;
 import io.muserver.rest.Description;
 import io.muserver.rest.ResponseHeader;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -51,7 +52,7 @@ public class BuildResource {
     @ApiResponse(code = "400", message = "No gitUrl form parameter was specified.", contentType = "text/plain")
     public Response create(@FormParam("gitUrl") @Description(value = "The URL of a git repo that includes a `build.sh` or `build.bat` file. " +
         "It can be any type of Git URL (e.g. SSH or HTTPS) that the server has permission for.", example = "https://github.com/3redronin/mu-server-sample.git") String gitUrl,
-                           @DefaultValue("master") @FormParam("branch") @Description(value = "The value of the git branch. This parameter is optional.") String branch,
+                           @FormParam("branch") @Description(value = "The value of the git branch. This parameter is optional.") String branch,
                            @FormParam("buildParam") @Description(value = "The parameter for the `build.sh` or `build.bat` file. This parameter is optional.") String buildParam,
                            @Context UriInfo uriInfo) {
         BuildResult result = createInternal(gitUrl, branch, buildParam, uriInfo);
@@ -69,11 +70,7 @@ public class BuildResource {
             throw new BadRequestException("A form parameter named gitUrl must point to a valid git repo");
         }
 
-        String gitBranch = branch;
-        if(null == branch || branch.trim().isEmpty()) {
-            gitBranch = "master";
-        }
-
+        String gitBranch = StringUtils.trimToNull(branch);
         GitRepo gitRepo = new GitRepo(gitUrl, gitBranch);
         String id = UUID.randomUUID().toString().replace("-", "");
         Map<String, String> environment = getEnrichedEnvironment(id, uriInfo);

--- a/src/main/resources/web/index.html
+++ b/src/main/resources/web/index.html
@@ -44,7 +44,7 @@
     </label>
     <label>
         Git Branch:
-        <input type="text" id="branchBox" name="branch"  placeholder="master">
+        <input type="text" id="branchBox" name="branch"  placeholder="<default>">
     </label>
     <label>
         Build Parameters:

--- a/src/main/resources/web/restabuild.js
+++ b/src/main/resources/web/restabuild.js
@@ -21,8 +21,13 @@ document.addEventListener('DOMContentLoaded', function () {
         var value = urlBox.value;
         var branch = branchBox.value;
         var buildParam = buildParamBox.value;
-        cc.textContent = 'curl -LNs -F \'gitUrl=' + (value || 'git-url') + '\' '  + '-F \'branch=' + (branch || 'master') + '\' ' + '-F \'param=' + (buildParam || '') + '\' ' + form.action;
-        history.replaceState(null, null, value ? encodeURI(path) + '?url=' + encodeURIComponent(value) : encodeURI(path));
+        cc.textContent = 'curl -LNs -F \'gitUrl=' + (value || 'git-url') + '\' '  + (branch ? ('-F \'branch=' + branch + '\' ') : '') + (buildParam ? ('-F \'param=' + buildParam + '\' ') : '') + form.action;
+        var encodedQS = '';
+        if (value) encodedQS += "&url="+encodeURIComponent(value);
+        if (branch) encodedQS += "&branch="+encodeURIComponent(branch);
+        if (buildParam) encodedQS += "&param="+encodeURIComponent(buildParam);
+        if (encodedQS) encodedQS = "?"+encodedQS.slice(1);
+        history.replaceState(null, null, encodeURI(path) + encodedQS);
     };
     urlBox.addEventListener('input', update);
     branchBox.addEventListener('input', update);

--- a/src/test/java/com/danielflower/restabuild/build/ProjectManagerTest.java
+++ b/src/test/java/com/danielflower/restabuild/build/ProjectManagerTest.java
@@ -3,6 +3,8 @@ package com.danielflower.restabuild.build;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.output.StringBuilderWriter;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import scaffolding.AppRepo;
 import scaffolding.TestConfig;
@@ -15,11 +17,22 @@ import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
 
 public class ProjectManagerTest {
 
-    private AppRepo appRepo = AppRepo.create("maven");
+    private AppRepo appRepo;
     private final int defaultTimeout = 30;
+
+    @Before
+    public void setUp() {
+        appRepo = AppRepo.create("maven");
+    }
+
+    @After
+    public void tearDown() {
+        appRepo.close();
+    }
 
     @Test
     public void canBuildProjectsAndPickUpChangesFromMasterBranch() throws Exception {
@@ -29,17 +42,86 @@ public class ProjectManagerTest {
         ProjectManager.ExtendedBuildState extendedBuildState = runner.build(buildLog, "master", null, defaultTimeout, System.getenv());
         assertThat(buildLog.toString(), extendedBuildState.buildState, is(BuildState.SUCCESS));
         assertThat(buildLog.toString(), containsString("BUILD SUCCESS"));
+        assertThat(extendedBuildState.branch, equalTo("master"));
         assertThat(extendedBuildState.tagsAdded, contains("my-maven-app-1.0.0"));
         assertThat("workDir does not still exist", extendedBuildState.workDir.exists(), is(false));
 
         breakTheProject(appRepo, "master");
 
         StringBuilderWriter badBuildLog = new StringBuilderWriter();
-        BuildState result2 = runner.build(badBuildLog, "master", null, defaultTimeout, System.getenv()).buildState;
-        assertThat(buildLog.toString(), result2, is(BuildState.FAILURE));
+        ProjectManager.ExtendedBuildState badExtendedBuildState = runner.build(badBuildLog, "master", null, defaultTimeout, System.getenv());
+        assertThat(badBuildLog.toString(), badExtendedBuildState.buildState, is(BuildState.FAILURE));
         assertThat(badBuildLog.toString(), containsString("The build could not read 1 project"));
+        assertThat(badExtendedBuildState.branch, equalTo("master"));
+        assertThat(badExtendedBuildState.tagsAdded, hasSize(0));
+        assertThat("workDir does not still exist", badExtendedBuildState.workDir.exists(), is(false));
+
+    }
+
+    @Test
+    public void canBuildProjectsUsingDefaultBranch() throws Exception {
+        StringBuilderWriter buildLog = new StringBuilderWriter();
+        ProjectManager runner = ProjectManager.create(appRepo.gitUrl(), TestConfig.testSandbox(), buildLog);
+        ProjectManager.ExtendedBuildState extendedBuildState = runner.build(buildLog, null, null, defaultTimeout, System.getenv());
+        assertThat(buildLog.toString(), extendedBuildState.buildState, is(BuildState.SUCCESS));
+        assertThat(buildLog.toString(), containsString("BUILD SUCCESS"));
+        assertThat(extendedBuildState.branch, equalTo("master"));
+        assertThat(extendedBuildState.tagsAdded, contains("my-maven-app-1.0.0"));
         assertThat("workDir does not still exist", extendedBuildState.workDir.exists(), is(false));
 
+        breakTheProject(appRepo, "master");
+        StringBuilderWriter badBuildLog = new StringBuilderWriter();
+        ProjectManager.ExtendedBuildState badExtendedBuildState = runner.build(badBuildLog, null, null, defaultTimeout, System.getenv());
+        assertThat(badBuildLog.toString(), badExtendedBuildState.buildState, is(BuildState.FAILURE));
+        assertThat(badBuildLog.toString(), containsString("The build could not read 1 project"));
+        assertThat(badExtendedBuildState.branch, equalTo("master"));
+        assertThat(badExtendedBuildState.tagsAdded, hasSize(0));
+        assertThat("workDir does not still exist", badExtendedBuildState.workDir.exists(), is(false));
+    }
+
+    @Test
+    public void canBuildProjectsWithADefaultBranchNotCalledMaster() throws Exception {
+        appRepo.origin.checkout().setName("branch-1").call();
+
+        StringBuilderWriter buildLog = new StringBuilderWriter();
+        ProjectManager runner = ProjectManager.create(appRepo.gitUrl(), TestConfig.testSandbox(), buildLog);
+        ProjectManager.ExtendedBuildState extendedBuildState = runner.build(buildLog, null, null, defaultTimeout, System.getenv());
+        assertThat(buildLog.toString(), extendedBuildState.buildState, is(BuildState.SUCCESS));
+        assertThat(buildLog.toString(), containsString("BUILD SUCCESS"));
+        assertThat(extendedBuildState.branch, equalTo("branch-1"));
+        assertThat(extendedBuildState.tagsAdded, contains("my-maven-app-1.0.0"));
+        assertThat("workDir does not still exist", extendedBuildState.workDir.exists(), is(false));
+
+        breakTheProject(appRepo, "branch-1");
+        StringBuilderWriter badBuildLog = new StringBuilderWriter();
+        ProjectManager.ExtendedBuildState badExtendedBuildState = runner.build(badBuildLog, null, null, defaultTimeout, System.getenv());
+        assertThat(badBuildLog.toString(), badExtendedBuildState.buildState, is(BuildState.FAILURE));
+        assertThat(badBuildLog.toString(), containsString("The build could not read 1 project"));
+        assertThat(badExtendedBuildState.branch, equalTo("branch-1"));
+        assertThat(badExtendedBuildState.tagsAdded, hasSize(0));
+        assertThat("workDir does not still exist", badExtendedBuildState.workDir.exists(), is(false));
+    }
+
+    @Test
+    public void canBuildProjectsUsingChangingDefaultBranch() throws Exception {
+        StringBuilderWriter buildLog = new StringBuilderWriter();
+        ProjectManager runner = ProjectManager.create(appRepo.gitUrl(), TestConfig.testSandbox(), buildLog);
+        ProjectManager.ExtendedBuildState extendedBuildState = runner.build(buildLog, null, null, defaultTimeout, System.getenv());
+        assertThat(buildLog.toString(), extendedBuildState.buildState, is(BuildState.SUCCESS));
+        assertThat(buildLog.toString(), containsString("BUILD SUCCESS"));
+        assertThat(extendedBuildState.branch, equalTo("master"));
+        assertThat(extendedBuildState.tagsAdded, contains("my-maven-app-1.0.0"));
+        assertThat("workDir does not still exist", extendedBuildState.workDir.exists(), is(false));
+
+
+        appRepo.origin.checkout().setName("branch-1").call();
+        StringBuilderWriter buildLog2 = new StringBuilderWriter();
+        ProjectManager.ExtendedBuildState extendedBuildState2 = runner.build(buildLog2, null, null, defaultTimeout, System.getenv());
+        assertThat(buildLog2.toString(), extendedBuildState2.buildState, is(BuildState.SUCCESS));
+        assertThat(buildLog2.toString(), containsString("BUILD SUCCESS"));
+        assertThat(extendedBuildState2.branch, equalTo("branch-1"));
+        assertThat(extendedBuildState2.tagsAdded, contains("my-maven-app-1.0.1"));
+        assertThat("workDir does not still exist", extendedBuildState2.workDir.exists(), is(false));
     }
 
     @Test
@@ -54,6 +136,7 @@ public class ProjectManagerTest {
         ProjectManager.ExtendedBuildState extendedBuildState = runner.build(buildLog, "master", null, defaultTimeout, System.getenv());
 
         String log = buildLog.toString();
+        assertThat(log, extendedBuildState.branch, equalTo("master"));
         assertThat(log, extendedBuildState.buildState, is(BuildState.SUCCESS));
         assertThat(log, extendedBuildState.commitIDBeforeBuild, is(commitIDAtStart));
         assertThat(log, extendedBuildState.commitIDAfterBuild, not(equalTo(commitIDAtStart)));
@@ -68,17 +151,18 @@ public class ProjectManagerTest {
         StringBuilderWriter buildLog = new StringBuilderWriter();
         ProjectManager runner = ProjectManager.create(appRepo.gitUrl(), TestConfig.testSandbox(), buildLog);
 
-        BuildState result = runner.build(buildLog, "branch-1", null, defaultTimeout, System.getenv()).buildState;
-        assertThat(buildLog.toString(), result, is(BuildState.SUCCESS));
+        ProjectManager.ExtendedBuildState extendedBuildState = runner.build(buildLog, "branch-1", null, defaultTimeout, System.getenv());
+        assertThat(buildLog.toString(), extendedBuildState.buildState, is(BuildState.SUCCESS));
         assertThat(buildLog.toString(), containsString("BUILD SUCCESS"));
+        assertThat(extendedBuildState.branch, equalTo("branch-1"));
 
         breakTheProject(appRepo, "branch-1");
 
         StringBuilderWriter badBuildLog = new StringBuilderWriter();
-        BuildState result2 = runner.build(badBuildLog, "branch-1", null, defaultTimeout, System.getenv()).buildState;
-        assertThat(buildLog.toString(), result2, is(BuildState.FAILURE));
+        ProjectManager.ExtendedBuildState badExtendedBuildState = runner.build(badBuildLog, "branch-1", null, defaultTimeout, System.getenv());
+        assertThat(badBuildLog.toString(), badExtendedBuildState.buildState, is(BuildState.FAILURE));
         assertThat(badBuildLog.toString(), containsString("The build could not read 1 project"));
-
+        assertThat(badExtendedBuildState.branch, equalTo("branch-1"));
     }
 
 
@@ -87,28 +171,32 @@ public class ProjectManagerTest {
         StringBuilderWriter buildLog = new StringBuilderWriter();
         ProjectManager runner = ProjectManager.create(appRepo.gitUrl(), TestConfig.testSandbox(), buildLog);
 
-        BuildState result = runner.build(buildLog, "master", null, defaultTimeout, System.getenv()).buildState;
-        assertThat(buildLog.toString(), result, is(BuildState.SUCCESS));
+        ProjectManager.ExtendedBuildState masterExtendedBuildState = runner.build(buildLog, "master", null, defaultTimeout, System.getenv());
+        assertThat(buildLog.toString(), masterExtendedBuildState.buildState, is(BuildState.SUCCESS));
         assertThat(buildLog.toString(), containsString("BUILD SUCCESS"));
+        assertThat(buildLog.toString(), masterExtendedBuildState.branch, equalTo("master"));
 
 
         StringBuilderWriter buildLogBranch1 = new StringBuilderWriter();
-        result = runner.build(buildLogBranch1, "branch-1", null, defaultTimeout, System.getenv()).buildState;
-        assertThat(buildLogBranch1.toString(), result, is(BuildState.SUCCESS));
+        ProjectManager.ExtendedBuildState branch1ExtendedBuildState = runner.build(buildLogBranch1, "branch-1", null, defaultTimeout, System.getenv());
+        assertThat(buildLogBranch1.toString(), branch1ExtendedBuildState.buildState, is(BuildState.SUCCESS));
         assertThat(buildLogBranch1.toString(), containsString("BUILD SUCCESS"));
+        assertThat(buildLogBranch1.toString(), branch1ExtendedBuildState.branch, equalTo("branch-1"));
 
         breakTheProject(appRepo, "branch-1");
 
         StringBuilderWriter buildLogMasterAgain = new StringBuilderWriter();
-        BuildState result2 = runner.build(buildLogMasterAgain, "master", null, defaultTimeout, System.getenv()).buildState;
-        assertThat(buildLogMasterAgain.toString(), result2, is(BuildState.SUCCESS));
+        ProjectManager.ExtendedBuildState masterExtendedBuildState2 = runner.build(buildLogMasterAgain, "master", null, defaultTimeout, System.getenv());
+        assertThat(buildLogMasterAgain.toString(), masterExtendedBuildState2.buildState, is(BuildState.SUCCESS));
         assertThat(buildLogMasterAgain.toString(),  containsString("BUILD SUCCESS"));
+        assertThat(buildLogMasterAgain.toString(), masterExtendedBuildState2.branch, equalTo("master"));
 
 
         StringBuilderWriter buildLogBranch1Again = new StringBuilderWriter();
-        BuildState branch1AgainResult = runner.build(buildLogBranch1Again, "branch-1", null, defaultTimeout, System.getenv()).buildState;
-        assertThat(buildLogBranch1Again.toString(), branch1AgainResult, is(BuildState.FAILURE));
+        ProjectManager.ExtendedBuildState branch1ExtendedBuildState2 = runner.build(buildLogBranch1Again, "branch-1", null, defaultTimeout, System.getenv());
+        assertThat(buildLogBranch1Again.toString(), branch1ExtendedBuildState2.buildState, is(BuildState.FAILURE));
         assertThat(buildLogBranch1Again.toString(),  containsString("The build could not read 1 project"));
+        assertThat(buildLogBranch1Again.toString(), branch1ExtendedBuildState2.branch, equalTo("branch-1"));
     }
 
     @Test


### PR DESCRIPTION
As of 5.10 jgit reads symrefs in pack capabilities and FetchResult can tell you the default branch.

If the FetchResult HEAD is a SymbolicRef then that is the default branch, build that,
else if there is a master which points to the same object as HEAD, build that,
else look for any branch that points to the same object as HEAD and build that.

That's the same logic as clone uses to determine which branch to start on.