### PR TITLE
Fix build order in case of large differences in queue start time

### DIFF
--- a/src/main/java/com/danielflower/restabuild/web/BuildResource.java
+++ b/src/main/java/com/danielflower/restabuild/web/BuildResource.java
@@ -124,7 +124,7 @@ public class BuildResource {
         JSONObject result = new JSONObject()
             .put("builds", new JSONArray(
                 database.all().stream()
-                    .sorted((o1, o2) -> (int) (o2.queueStart - o1.queueStart))
+                    .sorted((o1, o2) -> Long.compare(o2.queueStart, o1.queueStart))
                     .skip(skip)
                     .limit(limit)
                     .map(br -> jsonForResult(uriInfo.getRequestUriBuilder().path(br.id), br))


### PR DESCRIPTION
When restabuild is run for a long time, api/v1/builds returns builds in the wrong order. This was because the comperator in sorted was parsing the difference to int. If the difference exceeded the maximum integer value (approximately 25 days difference between the build dates), the result jumped to a negative value, so the values were incorrectly sorted.